### PR TITLE
Improve agent view toggle

### DIFF
--- a/src/pages/agent/Sidebar.js
+++ b/src/pages/agent/Sidebar.js
@@ -4,6 +4,12 @@ import styles from './styles.module.css';
 
 export const NAV = [
   {
+    label: 'Site',
+    items: [
+      {label: 'Home', href: '/agent/'},
+    ],
+  },
+  {
     label: 'Docs',
     items: [
       {label: 'Overview',       href: '/agent/docs?s=overview'},

--- a/src/pages/agent/index.js
+++ b/src/pages/agent/index.js
@@ -1,0 +1,91 @@
+import React, {useEffect, useRef, useState} from 'react';
+import Link from '@docusaurus/Link';
+import Layout from '@theme/Layout';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import AgentSidebar from './Sidebar';
+import styles from './styles.module.css';
+
+/* ─── Copy menu ───────────────────────────────────────────────────────────── */
+function CopyMenu({content, mdUrl}) {
+  const [open, setOpen] = useState(false);
+  const [label, setLabel] = useState(null);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    function onClickOutside(e) {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(false);
+    }
+    document.addEventListener('mousedown', onClickOutside);
+    return () => document.removeEventListener('mousedown', onClickOutside);
+  }, []);
+
+  function copy(text, tag) {
+    navigator.clipboard.writeText(text);
+    setLabel(tag);
+    setOpen(false);
+    setTimeout(() => setLabel(null), 2000);
+  }
+
+  return (
+    <div className={styles.copyWrap} ref={ref}>
+      <button className={styles.copyBtn} onClick={() => setOpen(o => !o)}>
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+        {label ?? 'Copy'}
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+      {open && (
+        <div className={styles.dropdown} role="menu">
+          <button role="menuitem" onClick={() => copy(mdUrl, '.md URL copied')}>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+            Copy .md URL
+          </button>
+          <button role="menuitem" onClick={() => copy(content, 'Copied!')}>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
+            Copy full content
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ─── Page ────────────────────────────────────────────────────────────────── */
+export default function AgentHomeView() {
+  const {siteConfig} = useDocusaurusContext();
+  const [content, setContent] = useState('');
+  const [loading, setLoading] = useState(true);
+  const mdUrl = `${siteConfig.url}/index.md`;
+
+  useEffect(() => {
+    document.body.dataset.agentView = 'true';
+    return () => { delete document.body.dataset.agentView; };
+  }, []);
+
+  useEffect(() => {
+    fetch('/index.md')
+      .then(r => r.text())
+      .then(text => {setContent(text); setLoading(false);})
+      .catch(() => {setContent('Failed to load content.'); setLoading(false);});
+  }, []);
+
+  return (
+    <Layout title="Home — Agent View" description="Machine-readable reShapr home page for AI agents and LLMs.">
+      <div className={styles.root}>
+        <AgentSidebar activeHref="/agent/" />
+        <div className={styles.main}>
+          <div className={styles.toolbar}>
+            <span className={styles.path}>→ /index.md</span>
+            <CopyMenu content={content} mdUrl={mdUrl} />
+          </div>
+          <pre className={styles.content}>
+            {loading ? 'Loading…' : content}
+          </pre>
+        </div>
+      </div>
+      <Link to="/" className={styles.viewToggle}>
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg>
+        Human View
+      </Link>
+    </Layout>
+  );
+}

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -3,8 +3,9 @@ import Link from '@docusaurus/Link';
 import { useLocation } from '@docusaurus/router';
 
 function getAgentHref(pathname) {
-  if (pathname.startsWith('/agent/')) return null;
+  if (pathname.startsWith('/agent/') || pathname === '/agent') return null;
 
+  if (pathname === '/' || pathname === '') return '/agent/';
   if (pathname.startsWith('/blog')) return '/agent/blog';
 
   if (pathname.startsWith('/docs/overview')) return '/agent/docs?s=overview';
@@ -23,7 +24,8 @@ function getAgentHref(pathname) {
   if (pathname.startsWith('/about')) return '/agent/about';
   if (pathname.startsWith('/community')) return '/agent/community';
 
-  return '/agent/blog';
+  // No page-specific equivalent — fall back to the agent homepage
+  return '/agent/';
 }
 
 export default function Root({ children }) {

--- a/static/index.md
+++ b/static/index.md
@@ -1,0 +1,51 @@
+# reShapr — Home
+
+> reShapr is the open-source, no-code MCP server for AI-native API access. It instantly converts existing REST, gRPC, and GraphQL APIs into secure, production-ready Model Context Protocol (MCP) endpoints — without writing a line of code.
+
+## What reShapr Does
+
+reShapr sits between your existing APIs and AI agents. Point it at an OpenAPI spec, gRPC proto, or GraphQL schema and it generates a fully functional MCP server that AI clients can discover and call. Authentication, authorization, context filtering, and deployment are all handled by reShapr — not your team.
+
+## Core capabilities
+
+- **No-code API translation** — Turn existing REST, GraphQL, and gRPC services into MCP endpoints without rewriting your backend.
+- **Security-first exposure** — Apply API key or OAuth protections, backend secrets, and operation filters before agents can call tools.
+- **Deploy Anywhere** — Expose endpoints on managed gateways or run gateways in your own trust domain for stricter data boundaries.
+- **Context control** — Filter which tools are exposed to which agents, preventing context overload and keeping LLM interactions precise.
+- **Gateway groups** — Logical groupings of MCP gateways for multi-tenant and multi-environment deployments.
+- **Hybrid deployment** — Run reShapr in the cloud, on-premise, or in hybrid configurations via Docker Compose or Helm charts.
+
+## Key highlights
+
+- OpenAPI, GraphQL, gRPC to MCP conversion
+- Security and policy controls before exposure
+- Cloud native and flexible deployment patterns
+- Fast setup with docs-first onboarding
+
+## Get started
+
+- Try reShapr: https://try.reshapr.io/
+- Getting started guide: https://reshapr.io/docs/tutorials/getting-started
+- How it works: https://reshapr.io/docs/overview/how-it-works
+- Why reShapr: https://reshapr.io/docs/overview/why-reshapr
+
+## Agent-readable site index
+
+- Home (this page): https://reshapr.io/index.md
+- Full site summary (llms.txt): https://reshapr.io/llms.txt
+- Docs overview: https://reshapr.io/docs/overview.md
+- Docs tutorials: https://reshapr.io/docs/tutorials.md
+- Docs how-to guides: https://reshapr.io/docs/how-to-guides.md
+- Docs explanations: https://reshapr.io/docs/explanations.md
+- Docs references: https://reshapr.io/docs/references.md
+- Docs demos: https://reshapr.io/docs/demos.md
+- Blog index: https://reshapr.io/blog.md
+- About: https://reshapr.io/about.md
+- Community: https://reshapr.io/community.md
+
+## Links
+
+- GitHub: https://github.com/reshaprio/reshapr.io
+- Discord: https://discord.gg/KyDUdam34h
+- LinkedIn: https://www.linkedin.com/company/reshapr
+- Bluesky: https://bsky.app/profile/reshapr.io


### PR DESCRIPTION
The catch-all in getAgentHref() sent every unmapped route (homepage, unknown pages) to /agent/blog, making the toggle feel broken. Users expect "show me this page in agent mode" but were redirected to the blog corpus regardless of context.

Changes:
- Map / explicitly to /agent/ (agent homepage)
- Change unmapped-route fallback from /agent/blog to /agent/
- Add /agent/ page with product summary, capabilities, and site index
- Add Home link to agent sidebar navigation