### PR TITLE
fix: agent view routing, mobile responsiveness improvements

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -14,8 +14,8 @@
  */
 .agent-view-toggle {
   position: fixed;
-  bottom: 1.5rem;
-  right: 1.5rem;
+  bottom: max(1.5rem, env(safe-area-inset-bottom, 0px));
+  right: max(1.5rem, env(safe-area-inset-right, 0px));
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
@@ -719,16 +719,16 @@ body,
    * the generic mobile rule below shrinks all `button.clean-btn` to 36px — override for `.navbar__toggle` only.
    */
   .navbar .navbar__toggle.clean-btn {
-    width: 96px !important;
-    min-width: 96px !important;
-    height: 96px !important;
-    min-height: 96px !important;
+    width: 56px !important;
+    min-width: 56px !important;
+    height: 56px !important;
+    min-height: 56px !important;
     flex-shrink: 0;
   }
 
   .navbar .navbar__toggle.clean-btn svg {
-    width: 48px !important;
-    height: 48px !important;
+    width: 28px !important;
+    height: 28px !important;
   }
 }
 
@@ -810,9 +810,9 @@ body,
   }
 
   .navbar-github-link {
-    width: 36px;
-    min-width: 36px;
-    height: 36px;
+    width: 44px;
+    min-width: 44px;
+    height: 44px;
     font-size: 0;
     line-height: 0;
     padding: 0;
@@ -843,8 +843,8 @@ body,
   }
 
   .navbar button.clean-btn:not(.navbar__toggle):not(.navbar-sidebar__back) {
-    width: 36px;
-    height: 36px;
+    width: 44px;
+    height: 44px;
   }
 
   .navbar button.clean-btn.reshapr-color-segmented {
@@ -944,18 +944,13 @@ body,
 
 @media (max-width: 360px) {
   .navbar__logo.navbar__logo-compact {
-    display: none !important;
+    height: 28px !important;
+    width: 28px !important;
+    max-height: 28px !important;
   }
 }
 
-@media (max-width: 1024px) {
-  .navbar-sidebar .navbar__logo.navbar__logo-full img,
-  .navbar-sidebar .navbar__logo.navbar__logo-compact {
-    height: var(--reshapr-navbar-logo-sidebar-height);
-    max-height: var(--reshapr-navbar-logo-sidebar-height);
-    transform: none;
-  }
-}
+/* Sidebar logo removed — navbar logo stays visible behind the drawer */
 
 .navbar__logo.navbar__logo-full img,
 img.navbar__logo.navbar__logo-compact {
@@ -1100,6 +1095,13 @@ img.navbar__logo.navbar__logo-compact {
     1.000123 89%,
     1.000088 90%
   );
+}
+
+/* Sidebar header: logo removed, compact close-button row */
+.navbar-sidebar .navbar-sidebar__brand {
+  min-height: 0;
+  height: auto;
+  padding: 0.5rem 0.75rem;
 }
 
 /* Infima: mobile drawer slide + fade — override timing to match reshapr interpolation tokens */
@@ -1636,6 +1638,16 @@ img.navbar__logo.navbar__logo-compact {
   .theme-blog-list-page article,
   .theme-blog-post-page article {
     padding-top: 1rem;
+  }
+
+  .theme-blog-post-page article header {
+    margin-bottom: 1.5rem;
+    padding-bottom: 1.25rem;
+  }
+
+  .theme-blog-post-page article header h1 {
+    font-size: clamp(1.5rem, 1.3rem + 0.7vw, 2rem);
+    margin-bottom: 0.75rem;
   }
 }
 

--- a/src/pages/about.module.css
+++ b/src/pages/about.module.css
@@ -191,4 +191,9 @@
     width: 72px;
     height: 72px;
   }
+
+  .socialLink {
+    width: 2.75rem;
+    height: 2.75rem;
+  }
 }

--- a/src/pages/agent/Sidebar.js
+++ b/src/pages/agent/Sidebar.js
@@ -29,35 +29,57 @@ export const NAV = [
   },
 ];
 
+const MOBILE_NAV = [
+  {label: 'Docs',  href: '/agent/docs?s=overview'},
+  {label: 'Blog',  href: '/agent/blog'},
+  {label: 'About', href: '/agent/about'},
+];
+
 export default function AgentSidebar({activeHref}) {
   return (
-    <nav className={styles.sidebar} aria-label="Site navigation">
-      <Link to="/" className={styles.sidebarHome}>
-        ~/reshapr
-      </Link>
-      {NAV.map(section => (
-        <div key={section.label} className={styles.sidebarSection}>
-          <p className={styles.sidebarLabel}>{section.label}</p>
-          <ul className={styles.sidebarList}>
-            {section.items.map(item => {
-              const isActive = activeHref
-                ? item.href === activeHref
-                : false;
-              return (
-                <li key={item.href}>
-                  <Link
-                    to={item.href}
-                    className={`${styles.sidebarLink} ${isActive ? styles.sidebarLinkActive : ''}`}
-                  >
-                    {isActive && <span className={styles.sidebarActiveDot} aria-hidden="true" />}
-                    {item.label}
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      ))}
-    </nav>
+    <>
+      <nav className={styles.sidebar} aria-label="Site navigation">
+        <Link to="/" className={styles.sidebarHome}>
+          ~/reshapr
+        </Link>
+        {NAV.map(section => (
+          <div key={section.label} className={styles.sidebarSection}>
+            <p className={styles.sidebarLabel}>{section.label}</p>
+            <ul className={styles.sidebarList}>
+              {section.items.map(item => {
+                const isActive = activeHref
+                  ? item.href === activeHref
+                  : false;
+                return (
+                  <li key={item.href}>
+                    <Link
+                      to={item.href}
+                      className={`${styles.sidebarLink} ${isActive ? styles.sidebarLinkActive : ''}`}
+                    >
+                      {isActive && <span className={styles.sidebarActiveDot} aria-hidden="true" />}
+                      {item.label}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))}
+      </nav>
+
+      <nav className={styles.mobileNav} aria-label="Site navigation">
+        <Link to="/" className={styles.mobileNavHome}>~/reshapr</Link>
+        <span className={styles.mobileNavSep} aria-hidden="true">/</span>
+        {MOBILE_NAV.map(item => (
+          <Link
+            key={item.href}
+            to={item.href}
+            className={`${styles.mobileNavLink} ${activeHref === item.href ? styles.mobileNavLinkActive : ''}`}
+          >
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+    </>
   );
 }

--- a/src/pages/agent/styles.module.css
+++ b/src/pages/agent/styles.module.css
@@ -216,9 +216,95 @@
   color: var(--ifm-link-color) !important;
 }
 
+/* ─── Mobile nav strip (hidden on desktop) ───────────────────────────────── */
+.mobileNav {
+  display: none;
+}
+
 /* ─── Responsive ─────────────────────────────────────────────────────────── */
 @media (max-width: 768px) {
+  .root {
+    flex-direction: column;
+  }
+
   .sidebar {
     display: none;
+  }
+
+  .mobileNav {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 1rem;
+    background: #111;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+    overflow-x: auto;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .mobileNavHome {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #63bbb6 !important;
+    text-decoration: none !important;
+    flex-shrink: 0;
+  }
+
+  .mobileNavHome:hover {
+    color: #9debe7 !important;
+  }
+
+  .mobileNavSep {
+    color: rgba(255, 255, 255, 0.2);
+    font-size: 0.75rem;
+    flex-shrink: 0;
+  }
+
+  .mobileNavLink {
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.5) !important;
+    text-decoration: none !important;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    flex-shrink: 0;
+    transition: color 0.12s, background 0.12s;
+  }
+
+  .mobileNavLink:hover {
+    color: rgba(255, 255, 255, 0.85) !important;
+  }
+
+  .mobileNavLinkActive {
+    color: #c9d1d9 !important;
+    background: rgba(255, 255, 255, 0.07);
+  }
+
+  .toolbar {
+    padding: 0.5rem 1rem;
+  }
+
+  .path {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .copyBtn {
+    min-height: 44px;
+    padding: 0.4rem 0.8rem;
+  }
+
+  .content {
+    padding: 1.25rem 1rem;
+    font-size: 0.8125rem;
+    line-height: 1.7;
+  }
+
+  .viewToggle {
+    bottom: max(1rem, env(safe-area-inset-bottom, 0px));
+    right: max(1rem, env(safe-area-inset-right, 0px));
+    font-size: 0.75rem;
+    padding: 0.4rem 0.9rem;
   }
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -115,8 +115,8 @@ function HomepageHeader() {
           animate="visible">
           <m.div variants={itemVariants}>
             <Heading as="h1" className={styles.heroTitle}>
-              The open source, no-code MCP Server for
-              <br />
+              The open source, no-code MCP Server for{' '}
+              <span className={styles.heroTitleBreak} />
               AI-Native API Access
             </Heading>
           </m.div>

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -231,6 +231,16 @@
   font-weight: 650;
 }
 
+.heroTitleBreak {
+  display: block;
+}
+
+@media screen and (max-width: 640px) {
+  .heroTitleBreak {
+    display: none;
+  }
+}
+
 .heroSubtitle {
   max-width: 680px;
   margin: 0;
@@ -664,10 +674,6 @@
     line-height: 1.6;
   }
 
-  .heroGrid {
-    grid-template-columns: 1fr;
-  }
-
   .heroBanner {
     grid-template-columns: 1fr;
     min-height: auto;
@@ -687,7 +693,7 @@
   }
 
   .heroSubtitle {
-    font-size: 1.05rem;
+    font-size: clamp(0.9375rem, 0.9rem + 0.3vw, 1.05rem);
   }
 
   .heroImageWrap .heroImage {
@@ -707,6 +713,12 @@
   .panel {
     grid-template-columns: 1fr;
     gap: var(--reshapr-space-7);
+  }
+
+  .cliCopyBtn {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 0.5rem;
   }
 
   .ctaCliRow {

--- a/src/theme/BlogListPage/styles.module.css
+++ b/src/theme/BlogListPage/styles.module.css
@@ -228,7 +228,7 @@
   }
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 996px) {
   .hero {
     grid-template-columns: 1fr;
     gap: 1.5rem;
@@ -236,10 +236,21 @@
     padding-bottom: 2.5rem;
   }
 
+  .heroImageWrap {
+    max-height: 280px;
+    order: 0;
+  }
+
   .heroTitle {
     font-size: clamp(1.75rem, 5vw, 2.35rem);
   }
 
+  .heroDescription {
+    -webkit-line-clamp: 3;
+  }
+}
+
+@media screen and (max-width: 768px) {
   .latestList {
     grid-template-columns: 1fr;
     gap: 1.5rem;
@@ -247,5 +258,9 @@
 
   .latestHeading {
     margin-bottom: 1rem;
+  }
+
+  .readMore {
+    font-size: 0.875rem;
   }
 }

--- a/src/theme/BlogPostItem/Header/Authors/styles.module.css
+++ b/src/theme/BlogPostItem/Header/Authors/styles.module.css
@@ -38,3 +38,16 @@
   font-size: 0.75rem;
   color: var(--ifm-color-emphasis-400);
 }
+
+@media (max-width: 768px) {
+  .byline {
+    gap: 0.3rem 0.5rem;
+    margin-top: 0.75rem;
+    font-size: 0.8125rem;
+  }
+
+  .avatar {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}

--- a/src/theme/BlogPostItem/styles.module.css
+++ b/src/theme/BlogPostItem/styles.module.css
@@ -27,3 +27,13 @@
 .breadcrumbBack:hover .breadcrumbArrow {
   transform: translateX(-4px);
 }
+
+@media (max-width: 768px) {
+  .breadcrumb {
+    margin-bottom: 1.25rem;
+  }
+
+  .breadcrumbBack {
+    font-size: 0.875rem;
+  }
+}

--- a/src/theme/Footer/styles.module.css
+++ b/src/theme/Footer/styles.module.css
@@ -14,7 +14,7 @@
   display: grid;
   grid-template-columns: repeat(3, auto);
   justify-content: center;
-  gap: var(--reshapr-space-10) 26rem;
+  gap: var(--reshapr-space-10) clamp(2rem, 12vw, 10rem);
   padding-bottom: var(--reshapr-space-12);
   border-bottom: 1px solid color-mix(in srgb, var(--ifm-color-emphasis-300) 20%, transparent);
 }
@@ -103,6 +103,20 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: var(--reshapr-space-8) var(--reshapr-space-8);
     padding-bottom: var(--reshapr-space-8);
+  }
+
+  .link {
+    font-size: 1rem;
+    padding: 0.375rem 0;
+    display: inline-block;
+  }
+
+  .socialLink {
+    padding: 0.5rem;
+  }
+
+  .socials {
+    gap: 0.5rem;
   }
 
   .bottom {

--- a/src/theme/Navbar/MobileSidebar/Header/index.js
+++ b/src/theme/Navbar/MobileSidebar/Header/index.js
@@ -8,7 +8,6 @@ import React from 'react';
 import {useNavbarMobileSidebar} from '@docusaurus/theme-common/internal';
 import {translate} from '@docusaurus/Translate';
 import IconClose from '@theme/Icon/Close';
-import NavbarLogo from '@theme/Navbar/Logo';
 
 function CloseButton() {
   const mobileSidebar = useNavbarMobileSidebar();
@@ -29,8 +28,7 @@ function CloseButton() {
 
 export default function NavbarMobileSidebarHeader() {
   return (
-    <div className="navbar-sidebar__brand">
-      <NavbarLogo />
+    <div className="navbar-sidebar__brand" style={{justifyContent: 'flex-end'}}>
       <CloseButton />
     </div>
   );

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -3,8 +3,9 @@ import Link from '@docusaurus/Link';
 import { useLocation } from '@docusaurus/router';
 
 function getAgentHref(pathname) {
-  if (pathname.startsWith('/agent/')) return null;
+  if (pathname.startsWith('/agent/') || pathname === '/agent') return null;
 
+  if (pathname === '/' || pathname === '') return '/agent/';
   if (pathname.startsWith('/blog')) return '/agent/blog';
 
   if (pathname.startsWith('/docs/overview')) return '/agent/docs?s=overview';
@@ -23,7 +24,7 @@ function getAgentHref(pathname) {
   if (pathname.startsWith('/about')) return '/agent/about';
   if (pathname.startsWith('/community')) return '/agent/community';
 
-  return '/agent/blog';
+  return '/agent/';
 }
 
 export default function Root({ children }) {

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,31 +1,7 @@
 import React, { useEffect } from 'react';
 import Link from '@docusaurus/Link';
 import { useLocation } from '@docusaurus/router';
-
-function getAgentHref(pathname) {
-  if (pathname.startsWith('/agent/') || pathname === '/agent') return null;
-
-  if (pathname === '/' || pathname === '') return '/agent/';
-  if (pathname.startsWith('/blog')) return '/agent/blog';
-
-  if (pathname.startsWith('/docs/overview')) return '/agent/docs?s=overview';
-  if (
-    pathname.includes('docker-compose') ||
-    pathname.includes('kubernetes') ||
-    pathname.includes('hybrid-gateway')
-  ) return '/agent/docs?s=how-to-guides';
-  if (pathname.startsWith('/docs/tutorials')) return '/agent/docs?s=tutorials';
-  if (pathname.startsWith('/docs/how-to-guides')) return '/agent/docs?s=how-to-guides';
-  if (pathname.startsWith('/docs/explanation')) return '/agent/docs?s=explanation';
-  if (pathname.startsWith('/docs/reference')) return '/agent/docs?s=reference';
-  if (pathname.startsWith('/docs/demos')) return '/agent/docs?s=demos';
-  if (pathname.startsWith('/docs')) return '/agent/docs?s=overview';
-
-  if (pathname.startsWith('/about')) return '/agent/about';
-  if (pathname.startsWith('/community')) return '/agent/community';
-
-  return '/agent/';
-}
+import { getAgentHref } from '@site/src/utils/agentRoutes';
 
 export default function Root({ children }) {
   const location = useLocation();

--- a/src/utils/agentRoutes.js
+++ b/src/utils/agentRoutes.js
@@ -1,0 +1,39 @@
+const DOCS_SECTION_MAP = {
+  '/docs/overview':       'overview',
+  '/docs/tutorials':      'tutorials',
+  '/docs/how-to-guides':  'how-to-guides',
+  '/docs/explanation':    'explanation',
+  '/docs/reference':      'reference',
+  '/docs/demos':          'demos',
+};
+
+const DOCS_KEYWORD_MAP = {
+  'docker-compose':   'how-to-guides',
+  'kubernetes':       'how-to-guides',
+  'hybrid-gateway':   'how-to-guides',
+};
+
+const SIMPLE_PREFIXES = ['/blog', '/about', '/community'];
+
+export function getAgentHref(pathname) {
+  if (pathname.startsWith('/agent/') || pathname === '/agent') return null;
+  if (pathname === '/' || pathname === '') return '/agent/';
+
+  // Docs: explicit section mapping (many-to-one)
+  if (pathname.startsWith('/docs')) {
+    for (const [prefix, section] of Object.entries(DOCS_SECTION_MAP)) {
+      if (pathname.startsWith(prefix)) return `/agent/docs?s=${section}`;
+    }
+    for (const [keyword, section] of Object.entries(DOCS_KEYWORD_MAP)) {
+      if (pathname.includes(keyword)) return `/agent/docs?s=${section}`;
+    }
+    return '/agent/docs?s=overview';
+  }
+
+  // Convention: /blog/* -> /agent/blog, /about/* -> /agent/about, etc.
+  for (const prefix of SIMPLE_PREFIXES) {
+    if (pathname.startsWith(prefix)) return `/agent${prefix}`;
+  }
+
+  return '/agent/';
+}


### PR DESCRIPTION
Restore agent view toggle routing (reverted in b29f5d0):
- Homepage and unmapped routes go to /agent/
- Explicit / → /agent/ mapping preserved

Mobile nav:
- Add inline nav strip for agent view on small screens
- Remove logo from mobile sidebar drawer header
- Compact sidebar header so "x" close button sits near menu items
- Reduce 96px hamburger to 56px
- Enlarge icon button touch targets to 44px (WCAG 2.5.5)

Layout and typography:
- Fix footer 26rem column gap causing overflow on medium viewports (now fluid clamp)
- Footer links: larger font, vertical padding, left-aligned at all breakpoints
- Blog hero: stack to single column at ≤996px (was 768px)
- Hero title: CSS-controlled line break (hidden on narrow screens)
- Hero subtitle: fluid clamp scaling for small viewports
- Logo: shrink at ≤360px instead of hiding

Touch targets and safe areas:
- Enlarge agent copy button, CLI copy button, about social links, footer social links
- Add safe-area-inset to view toggle pills for notched devices
- Agent toolbar path: truncate with ellipsis on overflow

Blog post pages:
- Add mobile styles for breadcrumb and author byline

Cleanup:
- Remove dead .heroGrid CSS rule