### PR TITLE
docs: add Tools Output Filtering reference spec

### DIFF
--- a/docs/references/spec-outtools-filtering.md
+++ b/docs/references/spec-outtools-filtering.md
@@ -1,0 +1,143 @@
+---
+description: Define ToolsFilters to trim, reshape, and conditionally rewrite MCP tool outputs before they reach the model, keeping the context window lean and the response surface deterministic.
+---
+
+# Tools Output Filtering
+
+As explained in **[Why reShapr?](../overview/why-reshapr.md)**, reShapr can create secure MCP servers in seconds without coding, just by importing your API's existing artifacts such as **[OpenAPI 3.x](https://www.openapis.org/)** specs, **[GraphQL](https://graphql.org/)** schemas, and **[gRPC/Protobuf](https://grpc.io/)** definitions. Once these artifacts are imported, the **[Custom Tools](./custom-tools-specification.md)** specification lets you redefine the *input* of a tool to fit a specific use case.
+
+`ToolsFilters` is the symmetrical capability on the *output* side: it lets you declaratively control what a tool returns to the model, before the response is wrapped into the JSON-RPC MCP envelope and sent back to the client.
+
+This matters for two reasons:
+
+- **Context economics.** A GraphQL node with many scalar properties, or a REST endpoint returning a deeply nested JSON tree, can easily consume thousands of tokens, most of which are irrelevant to the task at hand. Filtering at the gateway keeps the context window focused on what the model actually needs.
+- **Security and determinism.** Reusing a broad existing API often surfaces fields you'd rather not expose to an agent (PII, internal identifiers, expensive sub-trees). Filtering at the gateway gives you a single, declarative point of control, independent of the underlying API.
+
+reShapr applies filtering universally, regardless of the source protocol (REST, GraphQL, gRPC), because filters operate on the canonical JSON response produced by reShapr's protocol converters.
+
+## A first example
+
+Here is a simple `ToolsFilters` artifact that trims the response of a custom GitHub tool down to a single branch, removes a few sensitive or noisy fields, and rewrites one value:
+
+```yaml
+apiVersion: reshapr.io/v1alpha1
+kind: ToolsFilters
+service:
+  name: GitHub GraphQL
+  version: '20250917'
+filters:
+  get_user_with_latest_followers:
+    retain:
+      - /userInfo
+    patches:
+      - op: add
+        path: /userInfo/country
+        value: "France"
+      - op: remove
+        path: /userInfo/age
+      - op: remove
+        path: /userInfo/bioHTML
+      - op: remove
+        path: /userInfo/companyHTML
+      - op: remove
+        path: /userInfo/copilotEndpoints
+      - op: remove
+        path: /userInfo/monthlyEstimatedSponsorsIncomeInCents
+      - op: replace
+        path: /userInfo/city
+        value: Parigne Le Polin
+```
+
+A `ToolsFilters` artifact follows some simple rules:
+
+- It always contains an identification section made of `apiVersion` and `kind` properties that **must** have the **`reshapr.io/v1alpha1`** and `ToolsFilters` values respectively,
+- It **must** be bound to a specific reShapr **[Service](../explanations/services-and-artifacts.md)** using the **`service.name`** and `service.version` properties whose values **must** match an already discovered Service,
+- The `filters` section then defines the filters, keyed by tool name:
+  - The key (here `get_user_with_latest_followers`) **must** match an existing tool on the Service, either an imported tool or a **[Custom Tool](./custom-tools-specification.md)** previously attached to that Service,
+  - A filter entry **may** specify a `retain` block, an ordered `patches` block, or both,
+  - When both are present, `retain` **is always applied first**, as a pre-processing step that narrows the response, before `patches` are applied in order.
+
+You can specify as many tool filters as you want in the same `ToolsFilters` artifact, as long as each key targets a distinct tool of the bound Service.
+
+## The `retain` operation
+
+`retain` is reShapr's addition to the JSON Patch vocabulary. Standard JSON Patch (see below) only lets you describe what to *remove*, which is impractical when the response is a large object and you only care about a small subset of it. With `retain`, you declare the branches you want to *keep*, and everything else is dropped before patches run.
+
+- The value of `retain` **must** be a list of **[JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901)** paths,
+- Each listed path **must** resolve against the original tool response. Paths that don't resolve are silently ignored (a missing branch isn't an error, it's simply nothing to keep),
+- The order of paths in `retain` is not significant: `retain` describes a *set* of branches to keep,
+- If `retain` is omitted, the whole response is passed through to the `patches` step unchanged.
+
+## The `patches` operation
+
+`patches` is an ordered sequence of **[JSON Patch](https://jsonpatch.com/)** operations, applied in the listed order to whatever the `retain` step produced (or to the full response, when `retain` is omitted).
+
+reShapr supports the six standard JSON Patch operations:
+
+| Operation  | Effect                                                                                          |
+| ---------- | ----------------------------------------------------------------------------------------------- |
+| `add`      | Adds a value at the given path. Creates the field if it doesn't exist; inserts into arrays.     |
+| `replace`  | Replaces the value at the given path. The path **must** already exist.                          |
+| `remove`   | Removes the value at the given path.                                                            |
+| `copy`     | Copies the value from `from` to `path`.                                                         |
+| `move`     | Moves the value from `from` to `path` (equivalent to `copy` + `remove` on the source).          |
+| `test`     | Asserts that the value at `path` equals `value`. If the test fails, the patch sequence stops.   |
+
+- The value of `patches` **must** be a list of objects, each carrying an `op` property whose value **must** be one of the six operations above,
+- `path` **must** be a JSON Pointer that resolves against the working document (the response after `retain` has been applied),
+- `op: copy` and `op: move` **must** additionally specify a `from` JSON Pointer,
+- `op: add`, `replace`, and `test` **must** specify a `value`,
+- The order of the list is significant: each operation sees the document as modified by the operations that came before it.
+
+For the precise semantics of each operation, refer to **[RFC 6902: JavaScript Object Notation (JSON) Patch](https://datatracker.ietf.org/doc/html/rfc6902)**.
+
+## Conditional filtering
+
+Some tools return very different payloads depending on their inputs: a search endpoint that returns a person or an organisation, a polymorphic GraphQL union, a versioned REST resource. For these cases, `ToolsFilters` supports a conditional form where the filter for a tool is expressed as a **list** of branches, each guarded by a `test`:
+
+```yaml
+filters:
+  get_user_with_latest_followers:
+    - test:
+        path: /userInfo/type
+        value: PhysicalPerson
+      retain:
+        - /userInfo/person
+      patches:
+        - op: remove
+          path: /userInfo/person/ssn
+    - test:
+        path: /userInfo/type
+        value: MoralPerson
+      retain:
+        - /userInfo/entity
+      patches:
+        - op: remove
+          path: /userInfo/entity/taxId
+```
+
+Rules for the conditional form:
+
+- A conditional filter is a **list** of branches (as opposed to the simple form, which is a single object),
+- Each branch **must** declare a `test` block with `path` and `value`, using the same semantics as JSON Patch's `test` operation,
+- Each branch **may** declare `retain` and/or `patches`, with the same meaning as in the simple form,
+- Branches are evaluated **in order**. The first branch whose `test` succeeds is the one whose `retain` and `patches` are applied; remaining branches are skipped,
+- If no branch's `test` matches, the response is returned unchanged.
+
+## Naming and configuration scope
+
+Unlike `Prompts`, `Resources`, and `CustomTools`, which directly transform a Service, `ToolsFilters` is often driven by *deployment-time* concerns (security posture, audience, token budget) rather than by the Service itself. The same Service and the same Custom Tools can legitimately be exposed multiple times on different gateways, each with its own filter set: a public partner-facing Exposition might strip more fields than an internal one.
+
+For this reason, a future revision of the spec is expected to introduce a top-level `name` attribute on a `ToolsFilters` artifact, so that a **[Configuration Plan](../explanations/configuration-and-exposition.md)** can explicitly reference which filter set to apply at exposition time. Until that lands, a `ToolsFilters` artifact is bound to a Service and applies whenever that Service is exposed.
+
+## Where filters fit in the request lifecycle
+
+For a given MCP tool call, reShapr applies transformations in this order:
+
+1. The incoming MCP tool call is validated against the tool's input schema (the imported one, or the one defined by a **[Custom Tool](./custom-tools-specification.md)**).
+2. The call is converted to a protocol-specific request (REST, GraphQL, gRPC) and dispatched to the backend.
+3. The backend response is converted back into a canonical JSON response by reShapr's converters.
+4. **If a `ToolsFilters` artifact is attached to the Service and declares a filter for this tool, the filter is applied here: `retain` first, then `patches`.**
+5. The filtered response is wrapped into the JSON-RPC MCP envelope and returned to the client.
+
+Because filtering happens after the converter step and before the MCP envelope, the same `ToolsFilters` artifact applies uniformly whether the underlying tool is backed by REST, GraphQL, or gRPC.

--- a/docs/references/spec-outtools-filtering.md
+++ b/docs/references/spec-outtools-filtering.md
@@ -17,7 +17,7 @@ reShapr applies filtering universally, regardless of the source protocol (REST, 
 
 ## A first example
 
-Here is a simple `ToolsOutputFilters` artifact that trims the response of a custom GitHub tool down to a single branch, removes a few sensitive or noisy fields, and rewrites one value:
+Here is a simple `ToolsOutputFilters` artifact that trims the response of a custom GitHub tool down to a few key fields, removes a sensitive field, and adds a value:
 
 ```yaml
 apiVersion: reshapr.io/v1alpha1
@@ -27,25 +27,18 @@ service:
   version: '20250917'
 filters:
   get_user_with_latest_followers:
-    retain:
-      - /userInfo
-    patches:
+    jsonRetain:
+      - /data/user/name
+      - /data/user/login
+      - /data/user/bio
+      - /data/user/avatarUrl
+      - /data/user/followers
+    jsonPatches:
       - op: add
-        path: /userInfo/country
-        value: "France"
+        path: /data/user/location
+        value: "Worldwide"
       - op: remove
-        path: /userInfo/age
-      - op: remove
-        path: /userInfo/bioHTML
-      - op: remove
-        path: /userInfo/companyHTML
-      - op: remove
-        path: /userInfo/copilotEndpoints
-      - op: remove
-        path: /userInfo/monthlyEstimatedSponsorsIncomeInCents
-      - op: replace
-        path: /userInfo/city
-        value: Parigne Le Polin
+        path: /data/user/followers/nodes
 ```
 
 A `ToolsOutputFilters` artifact follows some simple rules:
@@ -54,23 +47,24 @@ A `ToolsOutputFilters` artifact follows some simple rules:
 - It **must** be bound to a specific reShapr **[Service](../explanations/services-and-artifacts.md)** using the **`service.name`** and `service.version` properties whose values **must** match an already discovered Service,
 - The `filters` section then defines the filters, keyed by tool name:
   - The key (here `get_user_with_latest_followers`) **must** match an existing tool on the Service, either an imported tool or a **[Custom Tool](./custom-tools-specification.md)** previously attached to that Service,
-  - A filter entry **may** specify a `retain` block, an ordered `patches` block, or both,
-  - When both are present, `retain` **is always applied first**, as a pre-processing step that narrows the response, before `patches` are applied in order.
+  - A filter entry **must** specify at least one of `jsonRetain`, `jsonPatches`, or `convertToToon`,
+  - When both `jsonRetain` and `jsonPatches` are present, `jsonRetain` **is always applied first**, as a pre-processing step that narrows the response, before `jsonPatches` are applied in order,
+  - `convertToToon` is applied last, after `jsonRetain` and `jsonPatches`.
 
 You can specify as many tool filters as you want in the same `ToolsOutputFilters` artifact, as long as each key targets a distinct tool of the bound Service.
 
-## The `retain` operation
+## The `jsonRetain` operation
 
-`retain` is reShapr's addition to the JSON Patch vocabulary. Standard JSON Patch (see below) only lets you describe what to *remove*, which is impractical when the response is a large object and you only care about a small subset of it. With `retain`, you declare the branches you want to *keep*, and everything else is dropped before patches run.
+`jsonRetain` is reShapr's addition to the JSON Patch vocabulary. Standard JSON Patch (see below) only lets you describe what to *remove*, which is impractical when the response is a large object and you only care about a small subset of it. With `jsonRetain`, you declare the branches you want to *keep*, and everything else is dropped before patches run.
 
-- The value of `retain` **must** be a list of **[JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901)** paths,
+- The value of `jsonRetain` **must** be a non-empty list of **[JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901)** paths,
 - Each listed path **must** resolve against the original tool response. Paths that don't resolve are silently ignored (a missing branch isn't an error, it's simply nothing to keep),
-- The order of paths in `retain` is not significant: `retain` describes a *set* of branches to keep,
-- If `retain` is omitted, the whole response is passed through to the `patches` step unchanged.
+- The order of paths in `jsonRetain` is not significant: `jsonRetain` describes a *set* of branches to keep,
+- If `jsonRetain` is omitted, the whole response is passed through to the `jsonPatches` step unchanged.
 
-## The `patches` operation
+## The `jsonPatches` operation
 
-`patches` is an ordered sequence of **[JSON Patch](https://jsonpatch.com/)** operations, applied in the listed order to whatever the `retain` step produced (or to the full response, when `retain` is omitted).
+`jsonPatches` is an ordered sequence of **[JSON Patch](https://jsonpatch.com/)** operations, applied in the listed order to whatever the `jsonRetain` step produced (or to the full response, when `jsonRetain` is omitted).
 
 reShapr supports the six standard JSON Patch operations:
 
@@ -83,46 +77,46 @@ reShapr supports the six standard JSON Patch operations:
 | `move`     | Moves the value from `from` to `path` (equivalent to `copy` + `remove` on the source).          |
 | `test`     | Asserts that the value at `path` equals `value`. If the test fails, the patch sequence stops.   |
 
-- The value of `patches` **must** be a list of objects, each carrying an `op` property whose value **must** be one of the six operations above,
-- `path` **must** be a JSON Pointer that resolves against the working document (the response after `retain` has been applied),
+- The value of `jsonPatches` **must** be a non-empty list of objects, each carrying an `op` property whose value **must** be one of the six operations above,
+- `path` **must** be a JSON Pointer that resolves against the working document (the response after `jsonRetain` has been applied),
 - `op: copy` and `op: move` **must** additionally specify a `from` JSON Pointer,
 - `op: add`, `replace`, and `test` **must** specify a `value`,
 - The order of the list is significant: each operation sees the document as modified by the operations that came before it.
 
 For the precise semantics of each operation, refer to **[RFC 6902: JavaScript Object Notation (JSON) Patch](https://datatracker.ietf.org/doc/html/rfc6902)**.
 
-## Conditional filtering
+## The `convertToToon` operation
 
-Some tools return very different payloads depending on their inputs: a search endpoint that returns a person or an organisation, a polymorphic GraphQL union, a versioned REST resource. For these cases, `ToolsOutputFilters` supports a conditional form where the filter for a tool is expressed as a **list** of branches, each guarded by a `test`:
+`convertToToon` converts the final filtered JSON output into **[Toon format](https://toonformat.dev/)**, a compact LLM-friendly representation that reduces token usage further.
+
+- The value of `convertToToon` **must** be `true`,
+- It is applied **last**, after `jsonRetain` and `jsonPatches` have run,
+- It can be used alone, or combined with `jsonRetain` and/or `jsonPatches`.
+
+Example using all three operations together:
 
 ```yaml
+apiVersion: reshapr.io/v1alpha1
+kind: ToolsOutputFilters
+service:
+  name: GitHub GraphQL
+  version: '20250917'
 filters:
   get_user_with_latest_followers:
-    - test:
-        path: /userInfo/type
-        value: PhysicalPerson
-      retain:
-        - /userInfo/person
-      patches:
-        - op: remove
-          path: /userInfo/person/ssn
-    - test:
-        path: /userInfo/type
-        value: MoralPerson
-      retain:
-        - /userInfo/entity
-      patches:
-        - op: remove
-          path: /userInfo/entity/taxId
+    jsonRetain:
+      - /data/user/name
+      - /data/user/login
+      - /data/user/bio
+      - /data/user/avatarUrl
+      - /data/user/followers
+    jsonPatches:
+      - op: add
+        path: /data/user/location
+        value: "Worldwide"
+      - op: remove
+        path: /data/user/followers/nodes
+    convertToToon: true
 ```
-
-Rules for the conditional form:
-
-- A conditional filter is a **list** of branches (as opposed to the simple form, which is a single object),
-- Each branch **must** declare a `test` block with `path` and `value`, using the same semantics as JSON Patch's `test` operation,
-- Each branch **may** declare `retain` and/or `patches`, with the same meaning as in the simple form,
-- Branches are evaluated **in order**. The first branch whose `test` succeeds is the one whose `retain` and `patches` are applied; remaining branches are skipped,
-- If no branch's `test` matches, the response is returned unchanged.
 
 ## Naming and configuration scope
 
@@ -137,7 +131,7 @@ For a given MCP tool call, reShapr applies transformations in this order:
 1. The incoming MCP tool call is validated against the tool's input schema (the imported one, or the one defined by a **[Custom Tool](./custom-tools-specification.md)**).
 2. The call is converted to a protocol-specific request (REST, GraphQL, gRPC) and dispatched to the backend.
 3. The backend response is converted back into a canonical JSON response by reShapr's converters.
-4. **If a `ToolsOutputFilters` artifact is attached to the Service and declares a filter for this tool, the filter is applied here: `retain` first, then `patches`.**
+4. **If a `ToolsOutputFilters` artifact is attached to the Service and declares a filter for this tool, the filter is applied here: `jsonRetain` first, then `jsonPatches`, then `convertToToon` if set.**
 5. The filtered response is wrapped into the JSON-RPC MCP envelope and returned to the client.
 
 Because filtering happens after the converter step and before the MCP envelope, the same `ToolsOutputFilters` artifact applies uniformly whether the underlying tool is backed by REST, GraphQL, or gRPC.

--- a/docs/references/spec-outtools-filtering.md
+++ b/docs/references/spec-outtools-filtering.md
@@ -1,12 +1,12 @@
 ---
-description: Define ToolsFilters to trim, reshape, and conditionally rewrite MCP tool outputs before they reach the model, keeping the context window lean and the response surface deterministic.
+description: Define ToolsOutputFilters to trim, reshape, and conditionally rewrite MCP tool outputs before they reach the model, keeping the context window lean and the response surface deterministic.
 ---
 
 # Tools Output Filtering
 
 As explained in **[Why reShapr?](../overview/why-reshapr.md)**, reShapr can create secure MCP servers in seconds without coding, just by importing your API's existing artifacts such as **[OpenAPI 3.x](https://www.openapis.org/)** specs, **[GraphQL](https://graphql.org/)** schemas, and **[gRPC/Protobuf](https://grpc.io/)** definitions. Once these artifacts are imported, the **[Custom Tools](./custom-tools-specification.md)** specification lets you redefine the *input* of a tool to fit a specific use case.
 
-`ToolsFilters` is the symmetrical capability on the *output* side: it lets you declaratively control what a tool returns to the model, before the response is wrapped into the JSON-RPC MCP envelope and sent back to the client.
+`ToolsOutputFilters` is the symmetrical capability on the *output* side: it lets you declaratively control what a tool returns to the model, before the response is wrapped into the JSON-RPC MCP envelope and sent back to the client.
 
 This matters for two reasons:
 
@@ -17,11 +17,11 @@ reShapr applies filtering universally, regardless of the source protocol (REST, 
 
 ## A first example
 
-Here is a simple `ToolsFilters` artifact that trims the response of a custom GitHub tool down to a single branch, removes a few sensitive or noisy fields, and rewrites one value:
+Here is a simple `ToolsOutputFilters` artifact that trims the response of a custom GitHub tool down to a single branch, removes a few sensitive or noisy fields, and rewrites one value:
 
 ```yaml
 apiVersion: reshapr.io/v1alpha1
-kind: ToolsFilters
+kind: ToolsOutputFilters
 service:
   name: GitHub GraphQL
   version: '20250917'
@@ -48,16 +48,16 @@ filters:
         value: Parigne Le Polin
 ```
 
-A `ToolsFilters` artifact follows some simple rules:
+A `ToolsOutputFilters` artifact follows some simple rules:
 
-- It always contains an identification section made of `apiVersion` and `kind` properties that **must** have the **`reshapr.io/v1alpha1`** and `ToolsFilters` values respectively,
+- It always contains an identification section made of `apiVersion` and `kind` properties that **must** have the **`reshapr.io/v1alpha1`** and `ToolsOutputFilters` values respectively,
 - It **must** be bound to a specific reShapr **[Service](../explanations/services-and-artifacts.md)** using the **`service.name`** and `service.version` properties whose values **must** match an already discovered Service,
 - The `filters` section then defines the filters, keyed by tool name:
   - The key (here `get_user_with_latest_followers`) **must** match an existing tool on the Service, either an imported tool or a **[Custom Tool](./custom-tools-specification.md)** previously attached to that Service,
   - A filter entry **may** specify a `retain` block, an ordered `patches` block, or both,
   - When both are present, `retain` **is always applied first**, as a pre-processing step that narrows the response, before `patches` are applied in order.
 
-You can specify as many tool filters as you want in the same `ToolsFilters` artifact, as long as each key targets a distinct tool of the bound Service.
+You can specify as many tool filters as you want in the same `ToolsOutputFilters` artifact, as long as each key targets a distinct tool of the bound Service.
 
 ## The `retain` operation
 
@@ -93,7 +93,7 @@ For the precise semantics of each operation, refer to **[RFC 6902: JavaScript Ob
 
 ## Conditional filtering
 
-Some tools return very different payloads depending on their inputs: a search endpoint that returns a person or an organisation, a polymorphic GraphQL union, a versioned REST resource. For these cases, `ToolsFilters` supports a conditional form where the filter for a tool is expressed as a **list** of branches, each guarded by a `test`:
+Some tools return very different payloads depending on their inputs: a search endpoint that returns a person or an organisation, a polymorphic GraphQL union, a versioned REST resource. For these cases, `ToolsOutputFilters` supports a conditional form where the filter for a tool is expressed as a **list** of branches, each guarded by a `test`:
 
 ```yaml
 filters:
@@ -126,9 +126,9 @@ Rules for the conditional form:
 
 ## Naming and configuration scope
 
-Unlike `Prompts`, `Resources`, and `CustomTools`, which directly transform a Service, `ToolsFilters` is often driven by *deployment-time* concerns (security posture, audience, token budget) rather than by the Service itself. The same Service and the same Custom Tools can legitimately be exposed multiple times on different gateways, each with its own filter set: a public partner-facing Exposition might strip more fields than an internal one.
+Unlike `Prompts`, `Resources`, and `CustomTools`, which directly transform a Service, `ToolsOutputFilters` is often driven by *deployment-time* concerns (security posture, audience, token budget) rather than by the Service itself. The same Service and the same Custom Tools can legitimately be exposed multiple times on different gateways, each with its own filter set: a public partner-facing Exposition might strip more fields than an internal one.
 
-For this reason, a future revision of the spec is expected to introduce a top-level `name` attribute on a `ToolsFilters` artifact, so that a **[Configuration Plan](../explanations/configuration-and-exposition.md)** can explicitly reference which filter set to apply at exposition time. Until that lands, a `ToolsFilters` artifact is bound to a Service and applies whenever that Service is exposed.
+For this reason, a future revision of the spec is expected to introduce a top-level `name` attribute on a `ToolsOutputFilters` artifact, so that a **[Configuration Plan](../explanations/configuration-and-exposition.md)** can explicitly reference which filter set to apply at exposition time. Until that lands, a `ToolsOutputFilters` artifact is bound to a Service and applies whenever that Service is exposed.
 
 ## Where filters fit in the request lifecycle
 
@@ -137,7 +137,7 @@ For a given MCP tool call, reShapr applies transformations in this order:
 1. The incoming MCP tool call is validated against the tool's input schema (the imported one, or the one defined by a **[Custom Tool](./custom-tools-specification.md)**).
 2. The call is converted to a protocol-specific request (REST, GraphQL, gRPC) and dispatched to the backend.
 3. The backend response is converted back into a canonical JSON response by reShapr's converters.
-4. **If a `ToolsFilters` artifact is attached to the Service and declares a filter for this tool, the filter is applied here: `retain` first, then `patches`.**
+4. **If a `ToolsOutputFilters` artifact is attached to the Service and declares a filter for this tool, the filter is applied here: `retain` first, then `patches`.**
 5. The filtered response is wrapped into the JSON-RPC MCP envelope and returned to the client.
 
-Because filtering happens after the converter step and before the MCP envelope, the same `ToolsFilters` artifact applies uniformly whether the underlying tool is backed by REST, GraphQL, or gRPC.
+Because filtering happens after the converter step and before the MCP envelope, the same `ToolsOutputFilters` artifact applies uniformly whether the underlying tool is backed by REST, GraphQL, or gRPC.

--- a/sidebars.js
+++ b/sidebars.js
@@ -140,6 +140,11 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'references/spec-outtools-filtering',
+          label: 'Tools Output Filtering',
+        },
+        {
+          type: 'doc',
           id: 'references/resources-specification',
           label: 'Resources Specification',
         },


### PR DESCRIPTION
## Summary

Adds the reference documentation for the **Tools Output Filtering** configuration schema (`ToolsFilters`, `apiVersion: reshapr.io/v1alpha1`) scheduled for `0.0.12`, as tracked in [reshaprio/reshapr#10](https://github.com/reshaprio/reshapr/issues/10).

Closes #16.

## What this PR adds

A new reference page at `docs/references/spec-outtools-filtering.md`, wired into the **References** sidebar (between *Custom Tools Specification* and *Resources Specification*).

The page documents:

- **Artifact identification** — `apiVersion` and `kind` rules, and the binding to a discovered Service via `service.name` / `service.version`.
- **Per-tool filter keys** — how a filter entry under `filters:` targets an existing imported tool or a previously attached Custom Tool.
- **The `retain` operation** — reShapr's addition to the JSON Patch vocabulary, applied as a pre-processing step that narrows the response before patches run. Rationale, JSON Pointer semantics, ordering, and missing-path behavior are all covered.
- **The `patches` operation** — the six standard JSON Patch operations (`add`, `replace`, `remove`, `copy`, `move`, `test`) with a reference table, the rules for `from` / `value`, ordering significance, and a pointer to RFC 6902.
- **Conditional filtering** — the list-of-branches form guarded by `test`, with rules on evaluation order and the "no branch matched" fallback. Mirrors the higher-level conditional construct proposed in reshapr#10.
- **Naming and configuration scope** — captures the open design question from reshapr#10 about `ToolsFilters` being driven by deployment-time concerns and the forward-looking `name` attribute that would let a Configuration Plan reference a specific filter set.
- **Request lifecycle** — where filtering fits: after the protocol converter produces the canonical JSON response, before the JSON-RPC MCP envelope is wrapped. Explains why the same artifact applies uniformly across REST, GraphQL, and gRPC.

## Files changed

- `docs/references/spec-outtools-filtering.md` *(new)*
- `sidebars.js` — adds the new doc to the References category

## Mapping to issue #16 requirements

| Issue #16 requirement | Where it's covered |
| --- | --- |
| Configuration structure mapping | "A first example" + bullet rules |
| Reference syntax and grammar rules | `retain`, `patches`, and Conditional filtering sections |
| Configuration boundaries | Per-tool keys, Service binding, Naming and configuration scope |
| Token optimization | "Context economics" bullet in the intro |
| Deterministic tool scoping | "Security and determinism" bullet + per-tool filter keys |
| Pointer to implementation | Link to reshapr#10 in the body |

## Test plan

- [x] `npm run build` succeeds (23 docs processed, new page included in `llms.txt` / `llms-full.txt`).
- [x] New page appears in the **References** sidebar between *Custom Tools Specification* and *Resources Specification*.
- [x] All internal links resolve (`../overview/why-reshapr.md`, `../explanations/services-and-artifacts.md`, `../explanations/configuration-and-exposition.md`, `./custom-tools-specification.md`).
- [x] All external links (jsonpatch.com, RFC 6901, RFC 6902, OpenAPI, GraphQL, gRPC) point to authoritative sources.
- [x] Commit is signed off (DCO).
