### PR TITLE
docs: emphasise standalone use of convertToToon in ToolsOutputFilters

### DIFF
--- a/docs/references/spec-outtools-filtering.md
+++ b/docs/references/spec-outtools-filtering.md
@@ -87,13 +87,27 @@ For the precise semantics of each operation, refer to **[RFC 6902: JavaScript Ob
 
 ## The `convertToToon` operation
 
-`convertToToon` converts the final filtered JSON output into **[Toon format](https://toonformat.dev/)**, a compact LLM-friendly representation that reduces token usage further.
+`convertToToon` converts the final filtered JSON output into **[Toon format](https://toonformat.dev/)**, a compact LLM-friendly representation that significantly reduces token usage.
 
 - The value of `convertToToon` **must** be `true`,
 - It is applied **last**, after `jsonRetain` and `jsonPatches` have run,
-- It can be used alone, or combined with `jsonRetain` and/or `jsonPatches`.
+- It can be used **alone** — without any `jsonRetain` or `jsonPatches` — and it will compact the full raw tool response as-is,
+- It works **regardless of the backend protocol**: REST, GraphQL, and gRPC tool responses are all converted to canonical JSON before filters run, so `convertToToon` applies uniformly across all three.
 
-Example using all three operations together:
+This makes `convertToToon: true` the simplest possible `ToolsOutputFilters` entry — a single key that immediately cuts token usage on any tool, without requiring you to know the response shape upfront:
+
+```yaml
+apiVersion: reshapr.io/v1alpha1
+kind: ToolsOutputFilters
+service:
+  name: GitHub GraphQL
+  version: '20250917'
+filters:
+  get_user_with_latest_followers:
+    convertToToon: true
+```
+
+You can also combine it with `jsonRetain` and `jsonPatches` to both shape and compact the response:
 
 ```yaml
 apiVersion: reshapr.io/v1alpha1


### PR DESCRIPTION
## Summary

Follow-up to #17 addressing @lbroudoux's review feedback on #16:

> *It could be nice to put more emphasis on the fact that it can be used without json operations and whatever the kind of backend.*

This PR rewrites the `convertToToon` section in [`spec-outtools-filtering.md`](docs/references/spec-outtools-filtering.md) to:

- **Spell out standalone use** — `convertToToon: true` can be used alone, without any `jsonRetain` or `jsonPatches`, and will compact the full raw tool response.
- **Spell out backend independence** — REST, GraphQL, and gRPC responses are all converted to canonical JSON before filters run, so `convertToToon` applies uniformly across all three.
- **Add a dedicated standalone example** showing the single-key form, before the existing combined-form example which is now framed as "You can also combine it…".